### PR TITLE
Handle nullable plugin call arguments

### DIFF
--- a/notificare_assets/android/src/main/kotlin/re/notifica/assets/flutter/NotificareAssetsPlugin.kt
+++ b/notificare_assets/android/src/main/kotlin/re/notifica/assets/flutter/NotificareAssetsPlugin.kt
@@ -38,7 +38,9 @@ class NotificareAssetsPlugin : FlutterPlugin, MethodCallHandler {
     }
 
     private fun fetch(@Suppress("UNUSED_PARAMETER") call: MethodCall, pluginResult: MethodChannel.Result) {
-        val group = call.arguments<String>()
+        val group = call.arguments<String>() ?: return onMainThread {
+            pluginResult.error(NOTIFICARE_ERROR, "Invalid request arguments.", null)
+        }
 
         Notificare.assets().fetch(group, object : NotificareCallback<List<NotificareAsset>> {
             override fun onSuccess(result: List<NotificareAsset>) {
@@ -58,6 +60,8 @@ class NotificareAssetsPlugin : FlutterPlugin, MethodCallHandler {
     internal companion object {
         internal const val NOTIFICARE_ERROR = "notificare_error"
 
-        internal fun onMainThread(action: () -> Unit) = Handler(Looper.getMainLooper()).post { action() }
+        internal fun onMainThread(action: () -> Unit) {
+            Handler(Looper.getMainLooper()).post { action() }
+        }
     }
 }

--- a/notificare_authentication/android/src/main/kotlin/re/notifica/authentication/flutter/NotificareAuthenticationPlugin.kt
+++ b/notificare_authentication/android/src/main/kotlin/re/notifica/authentication/flutter/NotificareAuthenticationPlugin.kt
@@ -162,7 +162,9 @@ class NotificareAuthenticationPlugin : FlutterPlugin, MethodCallHandler, Activit
     }
 
     private fun changePassword(@Suppress("UNUSED_PARAMETER") call: MethodCall, response: MethodChannel.Result) {
-        val password = call.arguments<String>()
+        val password = call.arguments<String>() ?: return onMainThread {
+            response.error(NOTIFICARE_ERROR, "Invalid request arguments.", null)
+        }
 
         Notificare.authentication().changePassword(password, object : NotificareCallback<Unit> {
             override fun onSuccess(result: Unit) {
@@ -199,7 +201,9 @@ class NotificareAuthenticationPlugin : FlutterPlugin, MethodCallHandler, Activit
     }
 
     private fun createAccount(@Suppress("UNUSED_PARAMETER") call: MethodCall, response: MethodChannel.Result) {
-        val arguments = call.arguments<JSONObject>()
+        val arguments = call.arguments<JSONObject>() ?: return onMainThread {
+            response.error(NOTIFICARE_ERROR, "Invalid request arguments.", null)
+        }
 
         val email = requireNotNull(call.argument<String>("email"))
         val password = requireNotNull(call.argument<String>("password"))
@@ -221,7 +225,9 @@ class NotificareAuthenticationPlugin : FlutterPlugin, MethodCallHandler, Activit
     }
 
     private fun validateUser(@Suppress("UNUSED_PARAMETER") call: MethodCall, response: MethodChannel.Result) {
-        val token = call.arguments<String>()
+        val token = call.arguments<String>() ?: return onMainThread {
+            response.error(NOTIFICARE_ERROR, "Invalid request arguments.", null)
+        }
 
         Notificare.authentication().validateUser(token, object : NotificareCallback<Unit> {
             override fun onSuccess(result: Unit) {
@@ -239,7 +245,9 @@ class NotificareAuthenticationPlugin : FlutterPlugin, MethodCallHandler, Activit
     }
 
     private fun sendPasswordReset(@Suppress("UNUSED_PARAMETER") call: MethodCall, response: MethodChannel.Result) {
-        val email = call.arguments<String>()
+        val email = call.arguments<String>() ?: return onMainThread {
+            response.error(NOTIFICARE_ERROR, "Invalid request arguments.", null)
+        }
 
         Notificare.authentication().sendPasswordReset(email, object : NotificareCallback<Unit> {
             override fun onSuccess(result: Unit) {
@@ -308,7 +316,11 @@ class NotificareAuthenticationPlugin : FlutterPlugin, MethodCallHandler, Activit
     }
 
     private fun addUserSegment(@Suppress("UNUSED_PARAMETER") call: MethodCall, response: MethodChannel.Result) {
-        val segment = NotificareUserSegment.fromJson(call.arguments())
+        val arguments = call.arguments<JSONObject>() ?: return onMainThread {
+            response.error(NOTIFICARE_ERROR, "Invalid request arguments.", null)
+        }
+
+        val segment = NotificareUserSegment.fromJson(arguments)
 
         Notificare.authentication().addUserSegment(segment, object : NotificareCallback<Unit> {
             override fun onSuccess(result: Unit) {
@@ -326,7 +338,11 @@ class NotificareAuthenticationPlugin : FlutterPlugin, MethodCallHandler, Activit
     }
 
     private fun removeUserSegment(@Suppress("UNUSED_PARAMETER") call: MethodCall, response: MethodChannel.Result) {
-        val segment = NotificareUserSegment.fromJson(call.arguments())
+        val arguments = call.arguments<JSONObject>() ?: return onMainThread {
+            response.error(NOTIFICARE_ERROR, "Invalid request arguments.", null)
+        }
+
+        val segment = NotificareUserSegment.fromJson(arguments)
 
         Notificare.authentication().removeUserSegment(segment, object : NotificareCallback<Unit> {
             override fun onSuccess(result: Unit) {
@@ -347,7 +363,9 @@ class NotificareAuthenticationPlugin : FlutterPlugin, MethodCallHandler, Activit
         @Suppress("UNUSED_PARAMETER") call: MethodCall,
         response: MethodChannel.Result
     ) {
-        val arguments = call.arguments<JSONObject>()
+        val arguments = call.arguments<JSONObject>() ?: return onMainThread {
+            response.error(NOTIFICARE_ERROR, "Invalid request arguments.", null)
+        }
 
         val preference = NotificareUserPreference.fromJson(requireNotNull(call.argument("preference")))
 
@@ -408,7 +426,9 @@ class NotificareAuthenticationPlugin : FlutterPlugin, MethodCallHandler, Activit
         @Suppress("UNUSED_PARAMETER") call: MethodCall,
         response: MethodChannel.Result
     ) {
-        val arguments = call.arguments<JSONObject>()
+        val arguments = call.arguments<JSONObject>() ?: return onMainThread {
+            response.error(NOTIFICARE_ERROR, "Invalid request arguments.", null)
+        }
 
         val preference = NotificareUserPreference.fromJson(requireNotNull(call.argument("preference")))
 
@@ -469,6 +489,8 @@ class NotificareAuthenticationPlugin : FlutterPlugin, MethodCallHandler, Activit
     internal companion object {
         internal const val NOTIFICARE_ERROR = "notificare_error"
 
-        internal fun onMainThread(action: () -> Unit) = Handler(Looper.getMainLooper()).post { action() }
+        internal fun onMainThread(action: () -> Unit) {
+            Handler(Looper.getMainLooper()).post { action() }
+        }
     }
 }

--- a/notificare_flutter/android/src/main/kotlin/re/notifica/flutter/NotificarePlugin.kt
+++ b/notificare_flutter/android/src/main/kotlin/re/notifica/flutter/NotificarePlugin.kt
@@ -163,7 +163,9 @@ class NotificarePlugin : FlutterPlugin, ActivityAware, PluginRegistry.NewIntentL
     }
 
     private fun fetchNotification(@Suppress("UNUSED_PARAMETER") call: MethodCall, response: Result) {
-        val id = call.arguments<String>()
+        val id = call.arguments<String>() ?: return onMainThread {
+            response.error(DEFAULT_ERROR_CODE, "Invalid request arguments.", null)
+        }
 
         Notificare.fetchNotification(id, object : NotificareCallback<NotificareNotification> {
             override fun onSuccess(result: NotificareNotification) {
@@ -189,7 +191,9 @@ class NotificarePlugin : FlutterPlugin, ActivityAware, PluginRegistry.NewIntentL
     }
 
     private fun register(call: MethodCall, pluginResult: Result) {
-        val arguments = call.arguments<JSONObject>()
+        val arguments = call.arguments<JSONObject>() ?: return onMainThread {
+            pluginResult.error(DEFAULT_ERROR_CODE, "Invalid request arguments.", null)
+        }
 
         val userId = if (!arguments.isNull("userId")) arguments.getString("userId") else null
         val userName = if (!arguments.isNull("userName")) arguments.getString("userName") else null
@@ -226,7 +230,9 @@ class NotificarePlugin : FlutterPlugin, ActivityAware, PluginRegistry.NewIntentL
     }
 
     private fun addTag(call: MethodCall, pluginResult: Result) {
-        val tag = call.arguments<String>()
+        val tag = call.arguments<String>() ?: return onMainThread {
+            pluginResult.error(DEFAULT_ERROR_CODE, "Invalid request arguments.", null)
+        }
 
         Notificare.device().addTag(tag, object : NotificareCallback<Unit> {
             override fun onSuccess(result: Unit) {
@@ -244,7 +250,9 @@ class NotificarePlugin : FlutterPlugin, ActivityAware, PluginRegistry.NewIntentL
     }
 
     private fun addTags(call: MethodCall, pluginResult: Result) {
-        val json = call.arguments<JSONArray>()
+        val json = call.arguments<JSONArray>() ?: return onMainThread {
+            pluginResult.error(DEFAULT_ERROR_CODE, "Invalid request arguments.", null)
+        }
 
         val tags = mutableListOf<String>()
         for (i in 0 until json.length()) {
@@ -267,7 +275,9 @@ class NotificarePlugin : FlutterPlugin, ActivityAware, PluginRegistry.NewIntentL
     }
 
     private fun removeTag(call: MethodCall, pluginResult: Result) {
-        val tag = call.arguments<String>()
+        val tag = call.arguments<String>() ?: return onMainThread {
+            pluginResult.error(DEFAULT_ERROR_CODE, "Invalid request arguments.", null)
+        }
 
         Notificare.device().removeTag(tag, object : NotificareCallback<Unit> {
             override fun onSuccess(result: Unit) {
@@ -285,7 +295,9 @@ class NotificarePlugin : FlutterPlugin, ActivityAware, PluginRegistry.NewIntentL
     }
 
     private fun removeTags(call: MethodCall, pluginResult: Result) {
-        val json = call.arguments<JSONArray>()
+        val json = call.arguments<JSONArray>() ?: return onMainThread {
+            pluginResult.error(DEFAULT_ERROR_CODE, "Invalid request arguments.", null)
+        }
 
         val tags = mutableListOf<String>()
         for (i in 0 until json.length()) {
@@ -362,7 +374,11 @@ class NotificarePlugin : FlutterPlugin, ActivityAware, PluginRegistry.NewIntentL
     }
 
     private fun updateDoNotDisturb(call: MethodCall, pluginResult: Result) {
-        val dnd = NotificareDoNotDisturb.fromJson(call.arguments())
+        val arguments = call.arguments<JSONObject>() ?: return onMainThread {
+            pluginResult.error(DEFAULT_ERROR_CODE, "Invalid request arguments.", null)
+        }
+
+        val dnd = NotificareDoNotDisturb.fromJson(arguments)
 
         Notificare.device().updateDoNotDisturb(dnd, object : NotificareCallback<Unit> {
             override fun onSuccess(result: Unit) {
@@ -412,7 +428,10 @@ class NotificarePlugin : FlutterPlugin, ActivityAware, PluginRegistry.NewIntentL
     }
 
     private fun updateUserData(call: MethodCall, pluginResult: Result) {
-        val json = call.arguments<JSONObject>()
+        val json = call.arguments<JSONObject>() ?: return onMainThread {
+            pluginResult.error(DEFAULT_ERROR_CODE, "Invalid request arguments.", null)
+        }
+
         val userData = mutableMapOf<String, String>()
 
         val iterator = json.keys()
@@ -477,6 +496,8 @@ class NotificarePlugin : FlutterPlugin, ActivityAware, PluginRegistry.NewIntentL
     internal companion object {
         const val DEFAULT_ERROR_CODE = "notificare_error"
 
-        internal fun onMainThread(action: () -> Unit) = Handler(Looper.getMainLooper()).post { action() }
+        internal fun onMainThread(action: () -> Unit) {
+            Handler(Looper.getMainLooper()).post { action() }
+        }
     }
 }

--- a/notificare_inbox/android/src/main/kotlin/re/notifica/inbox/flutter/NotificareInboxPlugin.kt
+++ b/notificare_inbox/android/src/main/kotlin/re/notifica/inbox/flutter/NotificareInboxPlugin.kt
@@ -10,6 +10,7 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
+import org.json.JSONObject
 import re.notifica.Notificare
 import re.notifica.NotificareCallback
 import re.notifica.inbox.flutter.events.NotificareEvent
@@ -95,7 +96,11 @@ class NotificareInboxPlugin : FlutterPlugin, MethodCallHandler {
     }
 
     private fun open(@Suppress("UNUSED_PARAMETER") call: MethodCall, pluginResult: Result) {
-        val item = NotificareInboxItem.fromJson(call.arguments())
+        val arguments = call.arguments<JSONObject>() ?: return onMainThread {
+            pluginResult.error(NOTIFICARE_ERROR, "Invalid request arguments.", null)
+        }
+
+        val item = NotificareInboxItem.fromJson(arguments)
 
         Notificare.inbox().open(item, object : NotificareCallback<NotificareNotification> {
             override fun onSuccess(result: NotificareNotification) {
@@ -113,7 +118,11 @@ class NotificareInboxPlugin : FlutterPlugin, MethodCallHandler {
     }
 
     private fun markAsRead(@Suppress("UNUSED_PARAMETER") call: MethodCall, pluginResult: Result) {
-        val item = NotificareInboxItem.fromJson(call.arguments())
+        val arguments = call.arguments<JSONObject>() ?: return onMainThread {
+            pluginResult.error(NOTIFICARE_ERROR, "Invalid request arguments.", null)
+        }
+
+        val item = NotificareInboxItem.fromJson(arguments)
 
         Notificare.inbox().markAsRead(item, object : NotificareCallback<Unit> {
             override fun onSuccess(result: Unit) {
@@ -139,7 +148,11 @@ class NotificareInboxPlugin : FlutterPlugin, MethodCallHandler {
     }
 
     private fun remove(@Suppress("UNUSED_PARAMETER") call: MethodCall, pluginResult: Result) {
-        val item = NotificareInboxItem.fromJson(call.arguments())
+        val arguments = call.arguments<JSONObject>() ?: return onMainThread {
+            pluginResult.error(NOTIFICARE_ERROR, "Invalid request arguments.", null)
+        }
+
+        val item = NotificareInboxItem.fromJson(arguments)
 
         Notificare.inbox().remove(item, object : NotificareCallback<Unit> {
             override fun onSuccess(result: Unit) {
@@ -153,7 +166,7 @@ class NotificareInboxPlugin : FlutterPlugin, MethodCallHandler {
     }
 
     private fun clear(@Suppress("UNUSED_PARAMETER") call: MethodCall, pluginResult: Result) {
-        Notificare.inbox() .clear(object : NotificareCallback<Unit> {
+        Notificare.inbox().clear(object : NotificareCallback<Unit> {
             override fun onSuccess(result: Unit) {
                 pluginResult.success(null)
             }
@@ -167,6 +180,8 @@ class NotificareInboxPlugin : FlutterPlugin, MethodCallHandler {
     companion object {
         internal const val NOTIFICARE_ERROR = "notificare_error"
 
-        internal fun onMainThread(action: () -> Unit) = Handler(Looper.getMainLooper()).post { action() }
+        internal fun onMainThread(action: () -> Unit) {
+            Handler(Looper.getMainLooper()).post { action() }
+        }
     }
 }

--- a/notificare_push_ui/android/src/main/kotlin/re/notifica/push/ui/flutter/NotificarePushUIPlugin.kt
+++ b/notificare_push_ui/android/src/main/kotlin/re/notifica/push/ui/flutter/NotificarePushUIPlugin.kt
@@ -70,7 +70,10 @@ public class NotificarePushUIPlugin : FlutterPlugin, MethodCallHandler, Activity
             return
         }
 
-        val notification = NotificareNotification.fromJson(call.arguments())
+        val arguments = call.arguments<JSONObject>()
+            ?: return result.error(NOTIFICARE_ERROR, "Invalid request arguments.", null)
+
+        val notification = NotificareNotification.fromJson(arguments)
 
         Notificare.pushUI().presentNotification(activity, notification)
         result.success(null)
@@ -84,6 +87,8 @@ public class NotificarePushUIPlugin : FlutterPlugin, MethodCallHandler, Activity
         }
 
         val json: JSONObject = call.arguments()
+            ?: return result.error(NOTIFICARE_ERROR, "Invalid request arguments.", null)
+
         val notification = NotificareNotification.fromJson(json.getJSONObject("notification"))
         val action = NotificareNotification.Action.fromJson(json.getJSONObject("action"))
 

--- a/notificare_scannables/android/src/main/kotlin/re/notifica/scannables/flutter/NotificareScannablesPlugin.kt
+++ b/notificare_scannables/android/src/main/kotlin/re/notifica/scannables/flutter/NotificareScannablesPlugin.kt
@@ -118,6 +118,7 @@ class NotificareScannablesPlugin : FlutterPlugin, MethodCallHandler, ActivityAwa
 
     private fun fetch(@Suppress("UNUSED_PARAMETER") call: MethodCall, response: Result) {
         val tag = call.arguments<String>()
+            ?: return response.error(NOTIFICARE_ERROR, "Invalid request arguments.", null)
 
         Notificare.scannables().fetch(tag, object : NotificareCallback<NotificareScannable> {
             override fun onSuccess(result: NotificareScannable) {


### PR DESCRIPTION
Flutter 3.0 declares plugin call arguments explicitly nullable.